### PR TITLE
Remove explicit dependencies...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,18 +380,6 @@
                     <groupId>org.kaazing</groupId>
                     <artifactId>robot-maven-plugin</artifactId>
                     <version>1.3.0.0</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.kaazing</groupId>
-                            <artifactId>robot.driver</artifactId>
-                            <version>1.3.0.0</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.kaazing</groupId>
-                            <artifactId>robot.websocket.functions</artifactId>
-                            <version>[0.0.0.0,0.1.0.0)</version>
-                        </dependency>
-                    </dependencies>
                     <configuration>
                         <skipTests>${skipITs}</skipTests>
                     </configuration>


### PR DESCRIPTION
...already specified in maven-robot-plugin project.

Having these present makes it seemingly impossible to update to a more recent version of maven-robot-plugin locally.

Any projects previously dependent on the websocket functions should update their dependency locally.  We should really consider these websocket functions as being a dependency of the scripts themselves, therefore as a local dependency to wherever the scripts are defined, not in the common plugin definition that spans all scripts.
